### PR TITLE
Fix undefined is not a function

### DIFF
--- a/js/color-thief.js
+++ b/js/color-thief.js
@@ -575,7 +575,7 @@ var MMCQ = (function() {
         // short-circuit
         if (!pixels.length || maxcolors < 2 || maxcolors > 256) {
 //            console.log('wrong number of maxcolors');
-            return false;
+            return new CMap();
         }
 
         // XXX: check color content and convert to grayscale if insufficient


### PR DESCRIPTION
If `MMCQ.quantize` has no pixels or if it has too many colors, the `return false` throw a TypeError Exception like this :

```
TypeError: undefined is not a function
    at ColorThief.getPaletteFromPixels (/home/throrin19/Development/Web/goomeoeventsapi/node_modules/color-thief/js/color-thief.js:182:24)
    at ColorThief.getPalette (/home/throrin19/Development/Web/goomeoeventsapi/node_modules/color-thief/js/color-thief.js:145:27)
    at ColorThief.getColor (/home/throrin19/Development/Web/goomeoeventsapi/node_modules/color-thief/js/color-thief.js:108:30)
    at getDominantColor (/home/throrin19/Development/Web/goomeoeventsapi/app/services/v1.2/image_service.js:34:29)
    at null. (/home/throrin19/Development/Web/goomeoeventsapi/app/facades/v1.2/uploader_facade.js:93:49)
    at gm. (/home/throrin19/Development/Web/goomeoeventsapi/app/services/v1.2/image_service.js:88:13)
    at gm.emit (events.js:110:17)
    at gm. (/home/throrin19/Development/Web/goomeoeventsapi/node_modules/gm/lib/getters.js:82:14)
    at cb (/home/throrin19/Development/Web/goomeoeventsapi/node_modules/gm/lib/command.js:314:16)
    at ChildProcess.proc.on.onExit (/home/throrin19/Development/Web/goomeoeventsapi/node_modules/gm/lib/command.js:289:9)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1015:16)
    at Socket. (child_process.js:1183:11)
    at Socket.emit (events.js:107:17)
    at Pipe.close (net.js:485:12)
```

This merge request fix the problem on change the `return false` by `return new CMap();`.