### PR TITLE
Fix up the node env test.

### DIFF
--- a/js/color-thief.js
+++ b/js/color-thief.js
@@ -24,13 +24,16 @@
 */
 
 var iAmOnNode = false;
-if (typeof process !== 'undefined' && process.execPath && process.execPath.indexOf('node') !== -1) {
+var Canvas;
+var Image;
+var fs;
+if ( !!process && process.execPath ) {
     iAmOnNode = true;
 }
 if (iAmOnNode) {
-  var Canvas = require('canvas');
-  var Image = Canvas.Image;
-  var fs = require('fs');
+  Canvas = require('canvas');
+  Image = Canvas.Image;
+  fs = require('fs');
 }
 
 var CanvasImage = function (image) {


### PR DESCRIPTION
We don't really need to test if process is explicitly undefined

We also don't want to test exec path specifically for the word `node`;
because iojs is not named node, and the nsolid node binaries from
nodesource are also not named node, etc