### PR TITLE
Fix building canvas on Windows 10 and npm 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/null2/color-thief/issues"
   },
   "dependencies": {
-    "canvas": "~1.2.0"
+    "canvas": "~1.4.0"
   },
   "devDependencies": {
     "nodeunit": "~0.8.2"


### PR DESCRIPTION
Building older verions of canvas might might fail with 
```
fatal error C1189: #error:  Macro definition of snprintf conflicts with Standard Library function declaration
```

under Windows 10, newer versions (>= 1.4.0) don't suffer from this.