### PR TITLE
Update to a version of canvas that will build on os x

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "url": "https://github.com/null2/color-thief/issues"
   },
   "dependencies": {
-    "canvas": "~1.4.0"
+    "canvas": "~1.6.11"
   },
   "devDependencies": {
     "nodeunit": "~0.8.2"


### PR DESCRIPTION
Color Thief currently fails to build on macOS. I've experienced this issue. lokesh/color-thief#118 appears to be the same issue (albeit posted in the wrong repository). And @ryanackley seems to have experienced it too.

Thankfully @ryanackley has published a fix. I've tried the same fix too, and can confirm it works.

Running `npm install color-thief` currently results in a very unwieldy block of error messages. Updating the canvas dependency appears to fix this. Please merge @ryanackley's fix.