### PR TITLE
Update Canvas to latest to support building on Linux / Ubuntu 18.04.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-thief",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "A script for grabbing the color palette from an image. Uses Javascript and the canvas tag to make it happen.",
   "main": "js/color-thief.js",
   "repository": {
@@ -16,7 +16,7 @@
     "url": "https://github.com/null2/color-thief/issues"
   },
   "dependencies": {
-    "canvas": "~1.6.11"
+    "canvas": "~2.5.0"
   },
   "devDependencies": {
     "nodeunit": "~0.8.2"


### PR DESCRIPTION
Right now installing on Linux results in an error. I'm not an expert but I believe it's directly related to issues building `canvas`. There are lots of installation issues detailed on their issue tracker [here](https://github.com/Automattic/node-canvas/issues/755).

This is impacting our ability to build one of our core projects on Linux. If a maintainer could update the `canvas` version in the `package.json` or approve this PR, merge, and publish (after testing of course) that would be fantastic. Thanks!

build error on linux:
```
> canvas@2.5.0 install /workspace/team3/project/node_modules/canvas
> node-pre-gyp install --fallback-to-build

node-pre-gyp WARN Using request for node-pre-gyp https download 
[canvas] Success: "/workspace/team3/project/node_modules/canvas/build/Release/canvas.node" is installed via remote

> canvas@1.1.6 install /workspace/team3/project/node_modules/color-thief/node_modules/canvas
> node-gyp rebuild

Package cairo was not found in the pkg-config search path.
Perhaps you should add the directory containing `cairo.pc'
to the PKG_CONFIG_PATH environment variable
No package 'cairo' found
gyp: Call to './util/has_cairo_freetype.sh' returned exit status 0 while in binding.gyp. while trying to load binding.gyp
gyp ERR! configure error 
gyp ERR! stack Error: `gyp` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onCpExit (/home/userwork/.nvm/versions/node/v10.10.0/lib/node_modules/npm/node_modules/node-gyp/lib/configure.js:345:16)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:240:12)
gyp ERR! System Linux 4.15.0-48-generic
gyp ERR! command "/home/userwork/.nvm/versions/node/v10.10.0/bin/node" "/home/userwork/.nvm/versions/node/v10.10.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild"
gyp ERR! cwd /workspace/team3/project/node_modules/color-thief/node_modules/canvas
gyp ERR! node -v v10.10.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok 
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.7 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.7: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! canvas@1.1.6 install: `node-gyp rebuild`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the canvas@1.1.6 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/userwork/.npm/_logs/2019-05-15T17_58_19_927Z-debug.log
Wed May 15 10:58 AM project: 
```

Successful install of latest `canvas` on Ubuntu 18.04.

```
Wed May 15 11:03 AM project: npm install canvas

> husky@1.3.1 install /workspace/team3/project/node_modules/husky
> node husky install

husky > setting up git hooks
husky > done

> canvas@2.5.0 install /workspace/team3/project/node_modules/canvas
> node-pre-gyp install --fallback-to-build

node-pre-gyp WARN Using request for node-pre-gyp https download 
[canvas] Success: "/workspace/team3/project/node_modules/canvas/build/Release/canvas.node" is installed via remote
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.4 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.4: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.7 (node_modules/chokidar/node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.7: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

+ canvas@2.5.0
added 2254 packages from 1009 contributors and audited 39527 packages in 26.958s
found 70 vulnerabilities (63 low, 7 high)
  run `npm audit fix` to fix them, or `npm audit` for details
```