### PR TITLE
fixes -- Canvas is not a constructor at new CanvasImage (.../node_mod…

### DIFF
--- a/js/color-thief.js
+++ b/js/color-thief.js
@@ -40,7 +40,7 @@ var CanvasImage = function (image) {
     // in node we use strings as path to an image
     // whereas in the browser we use an image element
     if (iAmOnNode) {
-      this.canvas = new Canvas()
+      this.canvas = Canvas.createCanvas()
       var img = new Image;
 
       if(image instanceof Buffer) {


### PR DESCRIPTION
…ules/color-thief/js/color-thief.js:42:19)

In node v11.6.0 on macOS Mojave, I get the error

Canvas is not a constructor at new CanvasImage 

(.../node_modules/color-thief/js/color-thief.js:42:19)
after some investigation, it appears that Canvas has changed it api which no longer uses the new Canvas() object and now uses Canvas.createCanvas()

Versions installed with yarn...

<img width="229" alt="Screenshot 2019-06-01 14 06 53" src="https://user-images.githubusercontent.com/3058459/58757207-34bd0900-84bd-11e9-9759-3f22921feca2.png">
